### PR TITLE
Switch terminology from "OEM Repo" to "Image Repo" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ The code below is intended to be run in five or more consoles:
 
 
 ###*WINDOW 1: the Image Repository*
-These instructions start a demonstration version of an OEM's or Supplier's main repository
-for software, hosting images and the metadata Uptane requires.
+These instructions start a demonstration version of an OEM's or Supplier's main
+repository for software, hosting images and the metadata Uptane requires.
 
 ```python
-import demo.demo_oem_repo as do
-do.clean_slate()
+import demo.demo_image_repo as di
+di.clean_slate()
 ```
 After the demo, to end hosting:
 ```python
-do.kill_server()
+di.kill_server()
 ```
 
 
@@ -165,8 +165,8 @@ Perform this *in the Image Repo's window* to create a new file, add it to the re
 ```python
 new_target_fname = filepath_in_repo = 'file5.txt'
 open(new_target_fname, 'w').write('Fresh target file')
-do.add_target_to_oemrepo(new_target_fname, filepath_in_repo)
-do.write_to_live()
+di.add_target_to_imagerepo(new_target_fname, filepath_in_repo)
+di.write_to_live()
 ```
 
 Perform this *in the Director Repository's window* to assign that Image file to vehicle 111, ECU 22222:

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -54,7 +54,7 @@ import os # For paths and symlink
 import shutil # For copying directory trees
 import sys, subprocess, time # For hosting
 import tuf.repository_tool as rt
-import demo.demo_oem_repo as demo_oem_repo # for the main repo directory /:
+import demo.demo_image_repo as demo_image_repo # for the main repo directory /:
 from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -1,17 +1,17 @@
 """
-demo_oem_repo.py
+demo_image_repo.py
 
 Demonstration code handling an OEM repository.
 
 Use:
 
-import demo.demo_oem_repo as do
-do.clean_slate()
-do.write_to_live()
-do.host()
+import demo.demo_image_repo as di
+di.clean_slate()
+di.write_to_live()
+di.host()
 
 # Later:
-do.kill_server()
+di.kill_server()
 
 
 
@@ -150,7 +150,7 @@ def write_to_live():
 
 
 
-def add_target_to_oemrepo(target_fname, filepath_in_repo):
+def add_target_to_imagerepo(target_fname, filepath_in_repo):
   """
   For use in attacks and more specific demonstration.
 
@@ -159,10 +159,10 @@ def add_target_to_oemrepo(target_fname, filepath_in_repo):
 
   <Arguments>
     target_fname
-      The full filename of the file to be added as a target to the OEM's
-      targets role metadata. This file should be in the targets subdirectory of
-      the repository directory.
-      This doesn't employ delegations, which would have to be done manually.
+      The full filename of the file to be added as a target to the image
+      repository's targets role metadata. This file should be in the targets
+      subdirectory of the repository directory.  This doesn't employ
+      delegations, which would have to be done manually.
   """
   global repo
 
@@ -260,7 +260,7 @@ def listen():
   # Register function that can be called via XML-RPC, allowing a Primary to
   # submit a vehicle version manifest.
   server.register_function(
-      add_target_to_oemrepo, 'add_target_to_supplier_repo')
+      add_target_to_imagerepo, 'add_target_to_supplier_repo')
   server.register_function(write_to_live, 'write_supplier_repo')
 
 


### PR DESCRIPTION
* Rename `demo_oem_repo.py` to `demo_image_repo.py`
* Rename `add_target_to_oemrepo()` to `add_target_to_imagerepo()`
* Update modified names in README.md

This is a fix for [issue #10](https://github.com/uptane/uptane/issues/10) on github.com/uptane/uptane